### PR TITLE
chore(release): bump version to 7.0.0-beta.58

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         run: yarn install --immutable
 
+      - name: Build package
+        if: steps.version_check.outputs.changed == 'true'
+        run: yarn build
+
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'
-        run: npm publish
+        run: npm publish --tag latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
       - name: yarn install
@@ -50,7 +50,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: react-18
           persist-credentials: false
@@ -73,10 +73,11 @@ jobs:
 
       - name: Setup .npmrc file for NPM registry
         if: steps.version_check.outputs.changed == 'true'
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never use caching in release builds
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 legacy-peer-deps = true
-install-scripts = false
+ignore-scripts = true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 The DataGrid component is designed to handle large datasets efficiently while offering a rich set of features for customization and interactivity.
 
+_Note: This package is a fork of [react-data-grid](https://github.com/Comcast/react-data-grid) with support for React 18._
+
 ## Features
 
 - [React 19.0+](package.json) support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/react-data-grid",
-  "version": "7.0.0-beta.56",
+  "version": "7.0.0-beta.57",
   "license": "MIT",
   "description": "Feature-rich and customizable data grid React component",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/grafana/react-data-grid.git"
+    "url": "http://github.com/grafana/react-data-grid.git"
   },
   "bugs": "https://github.com/grafana/react-data-grid/issues",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/react-data-grid",
-  "version": "7.0.0-beta.57",
+  "version": "7.0.0-beta.58",
   "license": "MIT",
   "description": "Feature-rich and customizable data grid React component",
   "keywords": [


### PR DESCRIPTION
[Manually published to NPM](https://www.npmjs.com/package/@grafana/react-data-grid) and trusted publishing is setup.

~We shouldn't merge this until trusted publishing is setup.~

~I've tested output by comparing the files in local copy of grafana/grafana `node_modules/react-data-grid/lib` to a local build of this branch and the differences look to be due to upstream fixes from rolldown and rolldown-dts-plugin. @fastfrwrd would you be willing to do the same and confirm for me I'm not missing anything here?~

~Once that is done I will manually publish this to NPM then do the trusted publishing dance and we can merge this PR.~


